### PR TITLE
Do not auto merge renovate changes

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>hmcts/.github:renovate-config",
-    "local>hmcts/.github//renovate/automerge-minor"
+    "local>hmcts/.github:renovate-config"
   ]
 }
 


### PR DESCRIPTION
### Change description
Renovate keeps merging things without permission. This is not how we work.