### PR TITLE
TPET-819: AAT smoke test database setup and Selenium retry handling

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -11,12 +11,18 @@ def vaultOverrides = [
   'preview': 'aat',
 ]
 
-def dbSecrets = [
+def previewDbSecrets = [
   secret('preview-password', 'DB_PASSWORD')
 ]
 
+def deployedDbSecrets = [
+  secret('tt-fqdn', 'DEPLOYED_DB_HOST'),
+  secret('tt-username', 'DEPLOYED_DB_USERNAME'),
+  secret('tt-password', 'DEPLOYED_DB_PASSWORD')
+]
+
 def secrets = [
-  'tax-tribunals-cft-${env}': dbSecrets,
+  'tax-tribunals-cft-${env}': deployedDbSecrets,
 ]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
@@ -29,7 +35,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 }
 
 withAzureKeyvault(
-    azureKeyVaultSecrets: dbSecrets,
+    azureKeyVaultSecrets: previewDbSecrets,
     keyVaultURLOverride: 'https://tax-tribunals-cft-aat.vault.azure.net/'
 ) {
     withPipeline(type, product, component) {
@@ -48,61 +54,79 @@ withAzureKeyvault(
         env.NODE_OPTIONS='--openssl-legacy-provider'
         env.ENABLE_COVERAGE='true'
 
-    // random free port should probably be used instead
-    env.GOVUK_NOTIFY_API_KEY = 'mocked_in_tests'
-    env.GLIMR_API_URL = 'replace_this_at_build_time'
-    env.GLIMR_DIRECT_API_URL = 'replace_this_at_build_time'
-    env.GLIMR_DIRECT_ENABLED = 'replace_this_at_build_time'
-    env.EXTERNAL_URL = 'replace_this_at_build_time'
-    env.PAYMENT_ENDPOINT = 'replace_this_at_build_time'
-    env.TAX_TRIBUNALS_DOWNLOADER_URL = 'replace_this_at_build_time'
-    env.SENTRY_DSN = 'replace_this_at_build_time'
-    env.GOVUK_NOTIFY_API_KEY = 'replace_this_at_build_time'
-    env.GTM_TRACKING_ID = 'replace_this_at_build_time'
-    env.TAX_TRIBUNAL_EMAIL = 'replace_this_at_build_time'
-    env.ZENDESK_USERNAME = 'replace_this_at_build_time'
-    env.ZENDESK_TOKEN = 'replace_this_at_build_time'
-    env.UPLOAD_PROBLEMS_REPORT_AUTH_USER = 'replace_this_at_build_time'
-    env.UPLOAD_PROBLEMS_REPORT_AUTH_DIGEST = 'replace_this_at_build_time'
-    env.ADMIN_USERNAME = 'replace_this_at_build_time'
-    env.ADMIN_PASSWORD = 'replace_this_at_build_time'
-    env.NOTIFY_CASE_CONFIRMATION_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_FTT_CASE_NOTIFICATION_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_NEW_CASE_SAVED_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_CHANGE_PASSWORD_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_RESET_PASSWORD_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_CASE_FIRST_REMINDER_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_CASE_LAST_REMINDER_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_REPORT_PROBLEM_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.REPORT_PROBLEM_EMAIL_ADDRESS = 'replace_this_at_build_time'
-    env.NOTIFY_SEND_APPLICATION_DETAIL_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_SEND_APPLICATION_DETAIL_TEXT_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_CASE_CONFIRMATION_CY_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_FTT_CASE_NOTIFICATION_CY_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_NEW_CASE_SAVED_CY_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_CHANGE_PASSWORD_CY_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_RESET_PASSWORD_CY_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_CASE_FIRST_REMINDER_CY_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_CASE_LAST_REMINDER_CY_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_REPORT_PROBLEM_CY_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_SEND_APPLICATION_DETAIL_CY_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.NOTIFY_SEND_APPLICATION_DETAIL_CY_TEXT_TEMPLATE_ID = 'replace_this_at_build_time'
-    env.ADDRESS_LOOKUP_ENDPOINT = 'https://api.os.uk/'
-    env.ADDRESS_LOOKUP_API_KEY = 'replace_this_at_build_time'
-    env.ADDRESS_LOOKUP_API_SECRET = 'replace_this_at_build_time'
-    env.DYNATRACE_UI_TRACKING_ID = 'replace_this_at_build_time'
+        // random free port should probably be used instead
+        env.GOVUK_NOTIFY_API_KEY = 'mocked_in_tests'
+        env.GLIMR_API_URL = 'replace_this_at_build_time'
+        env.GLIMR_DIRECT_API_URL = 'replace_this_at_build_time'
+        env.GLIMR_DIRECT_ENABLED = 'replace_this_at_build_time'
+        env.EXTERNAL_URL = 'replace_this_at_build_time'
+        env.PAYMENT_ENDPOINT = 'replace_this_at_build_time'
+        env.TAX_TRIBUNALS_DOWNLOADER_URL = 'replace_this_at_build_time'
+        env.SENTRY_DSN = 'replace_this_at_build_time'
+        env.GOVUK_NOTIFY_API_KEY = 'replace_this_at_build_time'
+        env.GTM_TRACKING_ID = 'replace_this_at_build_time'
+        env.TAX_TRIBUNAL_EMAIL = 'replace_this_at_build_time'
+        env.ZENDESK_USERNAME = 'replace_this_at_build_time'
+        env.ZENDESK_TOKEN = 'replace_this_at_build_time'
+        env.UPLOAD_PROBLEMS_REPORT_AUTH_USER = 'replace_this_at_build_time'
+        env.UPLOAD_PROBLEMS_REPORT_AUTH_DIGEST = 'replace_this_at_build_time'
+        env.ADMIN_USERNAME = 'replace_this_at_build_time'
+        env.ADMIN_PASSWORD = 'replace_this_at_build_time'
+        env.NOTIFY_CASE_CONFIRMATION_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_FTT_CASE_NOTIFICATION_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_NEW_CASE_SAVED_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_CHANGE_PASSWORD_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_RESET_PASSWORD_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_CASE_FIRST_REMINDER_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_CASE_LAST_REMINDER_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_REPORT_PROBLEM_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.REPORT_PROBLEM_EMAIL_ADDRESS = 'replace_this_at_build_time'
+        env.NOTIFY_SEND_APPLICATION_DETAIL_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_SEND_APPLICATION_DETAIL_TEXT_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_CASE_CONFIRMATION_CY_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_FTT_CASE_NOTIFICATION_CY_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_NEW_CASE_SAVED_CY_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_CHANGE_PASSWORD_CY_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_RESET_PASSWORD_CY_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_CASE_FIRST_REMINDER_CY_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_CASE_LAST_REMINDER_CY_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_REPORT_PROBLEM_CY_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_SEND_APPLICATION_DETAIL_CY_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.NOTIFY_SEND_APPLICATION_DETAIL_CY_TEXT_TEMPLATE_ID = 'replace_this_at_build_time'
+        env.ADDRESS_LOOKUP_ENDPOINT = 'https://api.os.uk/'
+        env.ADDRESS_LOOKUP_API_KEY = 'replace_this_at_build_time'
+        env.ADDRESS_LOOKUP_API_SECRET = 'replace_this_at_build_time'
+        env.DYNATRACE_UI_TRACKING_ID = 'replace_this_at_build_time'
 
-    before('build') {
-        yarnBuilder.runYarn("--mutex network install --frozen-lockfile")
-        sh script:"""#!/bin/bash -l
-            set -e
-            set +x
-            source /usr/local/rvm/scripts/rvm
-            rvm install ruby-3.4.8
-            rvm use ruby-3.4.8 --default
-            ruby --version
-        """, label: 'Ruby version install'
-    }
+        def useAatDatabase = {
+            env.DB_NAME = 'taxtribunals'
+            env.DB_USERNAME = env.DEPLOYED_DB_USERNAME
+            env.DB_PASSWORD = env.DEPLOYED_DB_PASSWORD
+            env.DB_HOST = env.DEPLOYED_DB_HOST
+            env.DB_PORT = '5432'
+            env.DATABASE_URL = "postgresql://${env.DB_USERNAME}@${env.DB_HOST}:${env.DB_PORT}/${env.DB_NAME}"
+            echo "Using AAT database for deployed tests: ${env.DB_HOST}/${env.DB_NAME}"
+        }
+
+        before('smoketest:aat') {
+            useAatDatabase()
+        }
+
+        before('functionalTest:aat') {
+            useAatDatabase()
+        }
+
+        before('build') {
+            yarnBuilder.runYarn("--mutex network install --frozen-lockfile")
+            sh script:"""#!/bin/bash -l
+                set -e
+                set +x
+                source /usr/local/rvm/scripts/rvm
+                rvm install ruby-3.4.8
+                rvm use ruby-3.4.8 --default
+                ruby --version
+            """, label: 'Ruby version install'
+        }
 
         before('test') {
             withEnv(['DISABLE_DATABASE_ENVIRONMENT_CHECK=1']) {

--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ Find a tax-tribunals-cft-aat key/vault on portal (https://portal.azure.com/#@HMC
 
 Copy azure-storage-account, azure-storage-container and azure-storage-key into your localhost .env setup accordingly.
 
-Trigger rebuild: 9
+Trigger rebuild: 8

--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ Find a tax-tribunals-cft-aat key/vault on portal (https://portal.azure.com/#@HMC
 
 Copy azure-storage-account, azure-storage-container and azure-storage-key into your localhost .env setup accordingly.
 
-Trigger rebuild: 8
+Trigger rebuild: 9

--- a/features/step_definitions/time_travel_steps.rb
+++ b/features/step_definitions/time_travel_steps.rb
@@ -44,6 +44,12 @@ Before do |scenario|
   @session_timeout_waited = false
 end
 
+After do
+  travel_back if respond_to?(:travel_back)
+  @session_timeout_should_trigger = false
+  @session_timeout_waited = false
+end
+
 When(/^I wait for (\d+) minutes$/) do |arg|
   travel arg.minutes
   if @session_timeout_should_trigger

--- a/features/support/selenium_inspector_node_retry.rb
+++ b/features/support/selenium_inspector_node_retry.rb
@@ -1,0 +1,27 @@
+# Chrome can report a stale DOM node as UnknownError instead of Selenium's
+# StaleElementReferenceError while a page is navigating or replacing content.
+# Let Capybara handle that specific inspector error through its normal retry loop.
+module SeleniumInspectorNodeRetry
+  TRANSIENT_INSPECTOR_NODE_ERRORS = [
+    'Node with given id does not belong to the document',
+    'No node with given id found',
+    'Could not find node with given id'
+  ].freeze
+
+  private
+
+  def catch_error?(error, errors = nil)
+    return true if errors.nil? && transient_selenium_inspector_node_error?(error)
+
+    super
+  end
+
+  def transient_selenium_inspector_node_error?(error)
+    return false unless defined?(Selenium::WebDriver::Error::UnknownError)
+    return false unless error.is_a?(Selenium::WebDriver::Error::UnknownError)
+
+    TRANSIENT_INSPECTOR_NODE_ERRORS.any? { |message| error.message.include?(message) }
+  end
+end
+
+Capybara::Node::Base.prepend(SeleniumInspectorNodeRetry)


### PR DESCRIPTION
### Jira link


See [TPET-819](https://tools.hmcts.net/jira/browse/TPET-819)

### Change description

Master smoke tests were failing because `DATABASE_URL` was still pointing at a PR-style preview database name, which DatabaseCleaner correctly rejected as unsafe. 

  - Load deployed AAT database secrets separately from the PR preview database password.
  - Override Jenkins DB env vars before AAT smoke and functional test stages so DatabaseCleaner targets the deployed AAT database instead of a `pr-${CHANGE_ID}` preview DB on master.
  - Add a Capybara patch to retry transient Selenium Chrome inspector node errors when the DOM is replaced during navigation that i've seen a few times recently.

